### PR TITLE
Add embedding loader for llama models

### DIFF
--- a/apps/backend/app/llm/__init__.py
+++ b/apps/backend/app/llm/__init__.py
@@ -1,0 +1,3 @@
+from .embedding_loader import get_embedding, parse_llama_args
+
+__all__ = ["get_embedding", "parse_llama_args"]

--- a/apps/backend/app/llm/embedding_loader.py
+++ b/apps/backend/app/llm/embedding_loader.py
@@ -1,0 +1,51 @@
+import os
+import logging
+import shlex
+from typing import Any, Dict, List
+
+try:
+    from llama_cpp import Llama
+except Exception as e:  # pragma: no cover - fallback or missing dependency
+    Llama = None  # type: ignore[misc]
+
+logger = logging.getLogger(__name__)
+
+
+def _convert_value(value: str) -> Any:
+    if value.lower() in {"true", "false"}:
+        return value.lower() == "true"
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+def parse_llama_args(env: str | None = None) -> Dict[str, Any]:
+    """Parse LLAMA_ARGS style environment variables into kwargs."""
+    raw = env if env is not None else os.getenv("LLAMA_ARGS", "")
+    args: Dict[str, Any] = {}
+    for token in shlex.split(raw):
+        if "=" in token:
+            key, val = token.split("=", 1)
+            args[key.lstrip("-")] = _convert_value(val)
+        else:
+            args[token.lstrip("-")] = True
+    return args
+
+
+def get_embedding(text: str, model_path: str, llama_args: Dict[str, Any] | None = None) -> List[float]:
+    """Return the embedding vector for *text* using a GGUF model."""
+    if Llama is None:
+        raise RuntimeError("llama_cpp is not available")
+
+    kwargs = parse_llama_args() if llama_args is None else llama_args
+    kwargs.setdefault("embedding", True)
+    try:
+        llm = Llama(model_path=model_path, **kwargs)
+        return llm.embed(text)
+    except Exception as e:  # pragma: no cover - runtime error if model missing
+        logger.error("embedding generation failed: %s", e)
+        raise

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -54,3 +54,4 @@ typing-inspection==0.4.0
 typing_extensions==4.13.1
 urllib3==2.4.0
 uvicorn==0.34.0
+exllamav2==0.3.2


### PR DESCRIPTION
## Summary
- add `llm` package with `get_embedding` helper
- parse `LLAMA_ARGS` from environment for llama options
- expose helper via `app.llm`
- include `exllamav2` in backend requirements

## Testing
- `python -m py_compile apps/backend/app/llm/embedding_loader.py apps/backend/app/llm/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_688530b9e5cc8326a2c64d0363bcab7b