### PR TITLE
Add reranker support

### DIFF
--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -2,3 +2,5 @@ SESSION_SECRET_KEY="a-secret-key"
 SYNC_DATABASE_URL="sqlite:///./app.db"
 ASYNC_DATABASE_URL="sqlite+aiosqlite:///./app.db"
 PYTHONDONTWRITEBYTECODE=1
+RERANK_PATH="Qwen3-Reranker-8B-Q8_0.safetensors"
+ENABLE_RERANK=false

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -14,6 +14,8 @@ class Settings(BaseSettings):
     SESSION_SECRET_KEY: Optional[str]
     DB_ECHO: bool = False
     PYTHONDONTWRITEBYTECODE: int = 1
+    RERANK_PATH: str = "Qwen3-Reranker-8B-Q8_0.safetensors"
+    ENABLE_RERANK: bool = False
 
     model_config = SettingsConfigDict(
         env_file=os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, ".env"),

--- a/apps/backend/app/llm/__init__.py
+++ b/apps/backend/app/llm/__init__.py
@@ -1,3 +1,4 @@
 from .embedding_loader import get_embedding, parse_llama_args
+from .reranker import rerank
 
-__all__ = ["get_embedding", "parse_llama_args"]
+__all__ = ["get_embedding", "parse_llama_args", "rerank"]

--- a/apps/backend/app/llm/reranker.py
+++ b/apps/backend/app/llm/reranker.py
@@ -1,0 +1,64 @@
+import os
+import logging
+from typing import Any, Dict, Iterable, List
+
+from .embedding_loader import parse_llama_args
+
+try:
+    from exllamav2 import ExLlamaV2, ExLlamaV2Config, ExLlamaV2Tokenizer
+    from exllamav2.generator import ExLlamaV2BaseGenerator
+except Exception:  # pragma: no cover - optional dependency
+    ExLlamaV2 = None  # type: ignore[misc]
+
+try:
+    from llama_cpp import Llama
+except Exception:  # pragma: no cover - optional dependency
+    Llama = None  # type: ignore[misc]
+
+logger = logging.getLogger(__name__)
+
+
+def rerank(
+    query: str,
+    docs: Iterable[str],
+    model_path: str | None = None,
+    llama_args: Dict[str, Any] | None = None,
+) -> List[float]:
+    """Return relevance scores for *docs* in relation to *query*."""
+
+    path = model_path or os.getenv("RERANK_PATH", "Qwen3-Reranker-8B-Q8_0.safetensors")
+    kwargs = parse_llama_args() if llama_args is None else llama_args
+
+    # Prefer exllamav2 when available
+    if ExLlamaV2 is not None:
+        try:
+            cfg = ExLlamaV2Config(path)
+            model = ExLlamaV2(cfg)
+            tokenizer = ExLlamaV2Tokenizer(cfg)
+            gen = ExLlamaV2BaseGenerator(model, tokenizer)
+            scores: List[float] = []
+            for doc in docs:
+                prompt = f"<query>{query}</query><doc>{doc}</doc>"
+                out = gen.generate_simple(prompt, max_new_tokens=1, **kwargs).strip()
+                try:
+                    scores.append(float(out))
+                except ValueError:
+                    scores.append(float('nan'))
+            return scores
+        except Exception as e:  # pragma: no cover - runtime error
+            logger.error("exllamav2 rerank failed: %s", e)
+
+    if Llama is None:
+        raise RuntimeError("llama_cpp is not available")
+
+    llm = Llama(model_path=path, **kwargs)
+    scores = []
+    for doc in docs:
+        prompt = f"<query>{query}</query><doc>{doc}</doc>"
+        out = llm(prompt, max_tokens=1, temperature=0)
+        text = out.get("choices", [{}])[0].get("text", "").strip()
+        try:
+            scores.append(float(text))
+        except ValueError:
+            scores.append(float("nan"))
+    return scores


### PR DESCRIPTION
## Summary
- implement LLama/exllamav2-based reranker
- expose RERANK_PATH and ENABLE_RERANK configuration
- update package exports
- document new environment variables

## Testing
- `python -m py_compile apps/backend/app/llm/reranker.py apps/backend/app/llm/__init__.py apps/backend/app/core/config.py`

------
https://chatgpt.com/codex/tasks/task_e_688531d46d9483269eaa62f3640ad937