### PR TITLE
Add env vars for local models

### DIFF
--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -1,6 +1,9 @@
 SESSION_SECRET_KEY="a-secret-key"
 SYNC_DATABASE_URL="sqlite:///./app.db"
 ASYNC_DATABASE_URL="sqlite+aiosqlite:///./app.db"
+# Optional model and llama settings
+# EMBED_PATH="nomic-embed-text:137m-v1.5-fp16"
+# RERANK_PATH="Qwen3-Reranker-8B-Q8_0.safetensors"
+# LLAMA_ARGS="--n-gpu-layers=1"
+# ENABLE_RERANK=false
 PYTHONDONTWRITEBYTECODE=1
-RERANK_PATH="Qwen3-Reranker-8B-Q8_0.safetensors"
-ENABLE_RERANK=false

--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -14,7 +14,9 @@ class Settings(BaseSettings):
     SESSION_SECRET_KEY: Optional[str]
     DB_ECHO: bool = False
     PYTHONDONTWRITEBYTECODE: int = 1
+    EMBED_PATH: str = "nomic-embed-text:137m-v1.5-fp16"
     RERANK_PATH: str = "Qwen3-Reranker-8B-Q8_0.safetensors"
+    LLAMA_ARGS: str = ""
     ENABLE_RERANK: bool = False
 
     model_config = SettingsConfigDict(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,15 @@ services:
       dockerfile: Dockerfile.backend
     ports:
       - "8000:8000"
-    environment:
-      <<: *ollama-env
-      SESSION_SECRET_KEY: "change-me"
-      SYNC_DATABASE_URL: "sqlite:///./data/app.db"
-      ASYNC_DATABASE_URL: "sqlite+aiosqlite:///./data/app.db"
+      environment:
+        <<: *ollama-env
+        SESSION_SECRET_KEY: "change-me"
+        SYNC_DATABASE_URL: "sqlite:///./data/app.db"
+        ASYNC_DATABASE_URL: "sqlite+aiosqlite:///./data/app.db"
+        EMBED_PATH: ${EMBED_PATH}
+        RERANK_PATH: ${RERANK_PATH}
+        LLAMA_ARGS: ${LLAMA_ARGS}
+        ENABLE_RERANK: ${ENABLE_RERANK}
     volumes:
       - ./apps/backend:/usr/src/app
       - sqlite-data:/usr/src/app/data


### PR DESCRIPTION
## Summary
- expose EMBED_PATH, RERANK_PATH, LLAMA_ARGS and ENABLE_RERANK in backend settings
- provide commented examples in `apps/backend/.env.sample`
- pass new vars through `docker-compose.yml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68853572cf0883269d97699a0ec25053