### PR TITLE
Document model paths and add env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ The project is built using:
 | Next.js      | 15+                   |
 | Ollama       |        0.6.7        |
 
+### Model Configuration
+
+The backend loads local models based on a few environment variables. Adjust these to point to custom models such as the Qwen3 series.
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `EMBED_PATH` | Name or path to a GGUF embedding model. | `nomic-embed-text:137m-v1.5-fp16` |
+| `RERANK_PATH` | Path to a Qwen3 reranker `.safetensors` file. | `Qwen3-Reranker-8B-Q8_0.safetensors` |
+| `LLAMA_ARGS` | Extra flags passed to the Llama backend. | `""` |
+| `ENABLE_RERANK` | Enable the reranking stage with the model above. | `false` |
+
+Example pointing to the open Qwen3 models:
+
+```bash
+export EMBED_PATH=/path/to/Qwen3-Embed-Model.gguf
+export RERANK_PATH=/path/to/Qwen3-Reranker-8B-Q8_0.safetensors
+export ENABLE_RERANK=true
+export LLAMA_ARGS="--n-gpu-layers=1"
+```
+
 
 ## Join Us and Contribute
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -103,8 +103,21 @@ You can customize any variables in these files before or after bootstrapping.
 | `PYTHONDONTWRITEBYTECODE` | Disable Python bytecode files   | `1`                            |
 | `ASYNC_DATABASE_URL`      | Backend async db connection URI | `sqlite+aiosqlite:///./app.db` |
 | `NEXT_PUBLIC_API_URL`     | Frontend proxy to backend URI   | `http://localhost:8000`        |
+| `EMBED_PATH`              | Name or path to embedding model  | `nomic-embed-text:137m-v1.5-fp16` |
+| `RERANK_PATH`             | Path to Qwen3 reranker model     | `Qwen3-Reranker-8B-Q8_0.safetensors` |
+| `LLAMA_ARGS`              | Extra arguments for llama backend | `""` |
+| `ENABLE_RERANK`           | Enable reranking stage           | `false` |
 
 > **Note:** `PYTHONDONTWRITEBYTECODE=1` is exported by `setup.sh` to prevent `.pyc` files.
+
+To use the open Qwen3 models instead of the defaults you can export variables before running the setup script:
+
+```bash
+export EMBED_PATH=/path/to/Qwen3-Embed-Model.gguf
+export RERANK_PATH=/path/to/Qwen3-Reranker-8B-Q8_0.safetensors
+export ENABLE_RERANK=true
+export LLAMA_ARGS="--n-gpu-layers=1"
+```
 
 ---
 

--- a/apps/backend/Dockerfile.backend
+++ b/apps/backend/Dockerfile.backend
@@ -4,6 +4,14 @@ WORKDIR /usr/src/app
 
 # ── install FastAPI stack
 ENV PIP_ROOT_USER_ACTION=ignore PIP_NO_CACHE_DIR=1
+ARG EMBED_PATH="nomic-embed-text:137m-v1.5-fp16"
+ARG RERANK_PATH="Qwen3-Reranker-8B-Q8_0.safetensors"
+ARG LLAMA_ARGS=""
+ARG ENABLE_RERANK=false
+ENV EMBED_PATH=${EMBED_PATH} \
+    RERANK_PATH=${RERANK_PATH} \
+    LLAMA_ARGS=${LLAMA_ARGS} \
+    ENABLE_RERANK=${ENABLE_RERANK}
 COPY requirements.txt .
 RUN pip install --upgrade pip && pip install -r requirements.txt
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "dnspython==2.7.0",
     "dotenv==0.9.9",
     "email_validator==2.2.0",
+    "exllamav2==0.3.2",
     "fastapi==0.115.12",
     "flatbuffers==25.2.10",
     "greenlet==3.1.1",

--- a/setup.sh
+++ b/setup.sh
@@ -120,12 +120,18 @@ if ! command -v ollama &> /dev/null; then
   success "Ollama installed"
 fi
 
-if ! ollama list | grep -q 'gemma3:4b'; then
-  info "Pulling gemma3:4b model…"
-  ollama pull gemma3:4b || error "Failed to pull gemma3:4b"
-  success "gemma3:4b model ready"
+EMBED_MODEL="${EMBED_PATH:-gemma3:4b}"
+# Pull Ollama model if EMBED_MODEL looks like an Ollama model name
+if [[ "$EMBED_MODEL" != */* && "$EMBED_MODEL" != *.gguf ]]; then
+  if ! ollama list | grep -q "${EMBED_MODEL}"; then
+    info "Pulling ${EMBED_MODEL} model…"
+    ollama pull "${EMBED_MODEL}" || error "Failed to pull ${EMBED_MODEL}"
+    success "${EMBED_MODEL} model ready"
+  else
+    info "${EMBED_MODEL} model already present—skipping"
+  fi
 else
-  info "gemma3:4b model already present—skipping"
+  info "Using local embedding model path ${EMBED_MODEL}"
 fi
 
 #–– 3. Bootstrap root .env ––#


### PR DESCRIPTION
## Summary
- document `EMBED_PATH`, `RERANK_PATH`, `LLAMA_ARGS` and `ENABLE_RERANK`
- show how to use the Qwen3 models
- expose model env vars in backend Dockerfile
- pull embedding model specified in `EMBED_PATH`
- add `exllamav2` to backend dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6885368874f083268546424e9a2fb713