### PR TITLE
Refactor GGUF embedding provider

### DIFF
--- a/apps/backend/app/agent/providers/gguf.py
+++ b/apps/backend/app/agent/providers/gguf.py
@@ -3,8 +3,7 @@ import os
 from typing import List
 
 from fastapi.concurrency import run_in_threadpool
-from llama_cpp import Llama
-from app.llm.embedding_loader import parse_llama_args
+from app.llm import get_embedding, parse_llama_args
 
 from .base import EmbeddingProvider
 from ..exceptions import ProviderError
@@ -19,17 +18,18 @@ class GGUFEmbeddingProvider(EmbeddingProvider):
         if not os.path.isfile(model_path):
             raise ProviderError(f"GGUF model not found at {model_path}")
         # Parse LLAMA_ARGS; these flags allow device-specific tuning
-        kwargs = parse_llama_args()
-        kwargs.setdefault("embedding", True)
-        try:
-            self._llama = Llama(model_path=model_path, **kwargs)
-        except Exception as e:  # pragma: no cover - runtime error if model missing
-            logger.error(f"gguf load error: {e}")
-            raise ProviderError(f"GGUF - Error loading model: {e}") from e
+        self._kwargs = parse_llama_args()
+        self._kwargs.setdefault("embedding", True)
+        self._model = model_path
 
     async def embed(self, text: str) -> List[float]:
         try:
-            return await run_in_threadpool(self._llama.embed, text)
+            return await run_in_threadpool(
+                get_embedding,
+                text,
+                self._model,
+                self._kwargs,
+            )
         except Exception as e:  # pragma: no cover - runtime error if model fails
             logger.error(f"gguf embedding error: {e}")
             raise ProviderError(f"GGUF - Error generating embedding: {e}") from e


### PR DESCRIPTION
## Summary
- streamline GGUFEmbeddingProvider by delegating to `llm.get_embedding`

## Testing
- `python -m compileall -q apps/backend/app`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68853d0fbc488326b7e2ff655d882ff0