### PR TITLE
Update backend env defaults and setup bootstrap

### DIFF
--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -4,6 +4,6 @@ ASYNC_DATABASE_URL="sqlite+aiosqlite:///./app.db"
 # Optional model and llama settings
 # EMBED_PATH="nomic-embed-text:137m-v1.5-fp16"
 # RERANK_PATH="Qwen3-Reranker-8B-Q8_0.safetensors"
-# LLAMA_ARGS="--n-gpu-layers=1"
+# LLAMA_ARGS=""
 # ENABLE_RERANK=false
 PYTHONDONTWRITEBYTECODE=1

--- a/setup.sh
+++ b/setup.sh
@@ -160,6 +160,11 @@ info "Setting up backend (apps/backend)…"
     info "Bootstrapping backend .env from .env.sample"
     cp .env.sample .env
     success "Backend .env created"
+    # Append model variables if exported
+    [[ -n "${EMBED_PATH:-}" ]] && printf '\nEMBED_PATH="%s"' "$EMBED_PATH" >> .env
+    [[ -n "${RERANK_PATH:-}" ]] && printf '\nRERANK_PATH="%s"' "$RERANK_PATH" >> .env
+    [[ -n "${LLAMA_ARGS:-}" ]] && printf '\nLLAMA_ARGS="%s"' "$LLAMA_ARGS" >> .env
+    [[ -n "${ENABLE_RERANK:-}" ]] && printf '\nENABLE_RERANK=%s' "$ENABLE_RERANK" >> .env
   else
     info "Backend .env exists or .env.sample missing—skipping"
   fi


### PR DESCRIPTION
## Summary
- sync backend `.env.sample` defaults with `config.py`
- append exported model env vars to `.env` when bootstrapping backend in `setup.sh`

## Testing
- `npm run lint` *(fails: Could not find `prettier` plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68853edf863c8326a5ac1bc9998b25be