### PR TITLE
Update backend memory limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
       retries: 5
-    mem_limit: 1g
+    mem_limit: 8g
     restart: unless-stopped
 
   frontend:


### PR DESCRIPTION
## Summary
- increase the memory limit for the backend service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6885419ce47483268343feed187bcde0