### PR TITLE
Handle dashes in LLAMA_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The backend loads local models based on a few environment variables. Adjust thes
 | -------- | ------- | ------- |
 | `EMBED_PATH` | Name or path to a GGUF embedding model. | `nomic-embed-text:137m-v1.5-fp16` |
 | `RERANK_PATH` | Path to a Qwen3 reranker `.safetensors` file. | `Qwen3-Reranker-8B-Q8_0.safetensors` |
-| `LLAMA_ARGS` | Extra flags passed to the Llama backend. | `""` |
+| `LLAMA_ARGS` | Extra flags passed to the Llama backend (dashes become underscores). | `""` |
 | `ENABLE_RERANK` | Enable the reranking stage with the model above. | `false` |
 
 Example pointing to the open Qwen3 models:
@@ -104,6 +104,8 @@ export RERANK_PATH=/path/to/Qwen3-Reranker-8B-Q8_0.safetensors
 export ENABLE_RERANK=true
 export LLAMA_ARGS="--n-gpu-layers=1"
 ```
+
+Dashes in keys are converted to underscores, so the example above becomes `n_gpu_layers=1` when parsed.
 
 
 ## Join Us and Contribute

--- a/SETUP.md
+++ b/SETUP.md
@@ -105,7 +105,7 @@ You can customize any variables in these files before or after bootstrapping.
 | `NEXT_PUBLIC_API_URL`     | Frontend proxy to backend URI   | `http://localhost:8000`        |
 | `EMBED_PATH`              | Name or path to embedding model  | `nomic-embed-text:137m-v1.5-fp16` |
 | `RERANK_PATH`             | Path to Qwen3 reranker model     | `Qwen3-Reranker-8B-Q8_0.safetensors` |
-| `LLAMA_ARGS`              | Extra arguments for llama backend | `""` |
+| `LLAMA_ARGS`              | Extra arguments for llama backend (dashes become underscores). | `""` |
 | `ENABLE_RERANK`           | Enable reranking stage           | `false` |
 
 > **Note:** `PYTHONDONTWRITEBYTECODE=1` is exported by `setup.sh` to prevent `.pyc` files.
@@ -118,6 +118,8 @@ export RERANK_PATH=/path/to/Qwen3-Reranker-8B-Q8_0.safetensors
 export ENABLE_RERANK=true
 export LLAMA_ARGS="--n-gpu-layers=1"
 ```
+
+Dashes in keys are converted to underscores, so the example above becomes `n_gpu_layers=1` when parsed.
 
 ---
 

--- a/apps/backend/app/llm/embedding_loader.py
+++ b/apps/backend/app/llm/embedding_loader.py
@@ -30,9 +30,9 @@ def parse_llama_args(env: str | None = None) -> Dict[str, Any]:
     for token in shlex.split(raw):
         if "=" in token:
             key, val = token.split("=", 1)
-            args[key.lstrip("-")] = _convert_value(val)
+            args[key.lstrip("-").replace("-", "_")] = _convert_value(val)
         else:
-            args[token.lstrip("-")] = True
+            args[token.lstrip("-").replace("-", "_")] = True
     return args
 
 


### PR DESCRIPTION
## Summary
- normalize hyphenated keys in `parse_llama_args`
- note underscore conversion in README and SETUP docs

## Testing
- `python -m py_compile apps/backend/app/llm/embedding_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_688544c12f8c8326ab26abcbb785ac0e