### PR TITLE
Update default embedding model

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -132,7 +132,7 @@ export LLAMA_ARGS="--n-gpu-layers=1"
  ollama serve
  ```
 
- If Ollama is not running, the script may fail to pull the required model (`gemma3:4b`).
+If Ollama is not running, the script may fail to pull the required model (`nomic-embed-text:137m-v1.5-fp16`).
  
 ### Windows Installation
 
@@ -153,7 +153,7 @@ export LLAMA_ARGS="--n-gpu-layers=1"
 
    - Verify/install prerequisites (`node`, `npm`, `python3`, `pip3`, `uv`)
    - Install Ollama via winget (if not present)
-   - Pull the `gemma3:4b` model via Ollama
+  - Pull the `nomic-embed-text:137m-v1.5-fp16` model via Ollama
    - Bootstrap root & backend `.env` files
    - Install Node.js deps (`npm ci`) at root and frontend
    - Sync Python deps in `apps/backend` via `uv sync`
@@ -195,7 +195,7 @@ export LLAMA_ARGS="--n-gpu-layers=1"
    This will:
 
    - Verify/install prerequisites (`node`, `npm`, `python3`, `pip3`, `uv`, `ollama`)
-   - Pull the `gemma3:4b` model via Ollama
+  - Pull the `nomic-embed-text:137m-v1.5-fp16` model via Ollama
    - Bootstrap root & backend `.env` files
    - Install Node.js deps (`npm ci`) at root and frontend
    - Sync Python deps in `apps/backend` via `uv sync`

--- a/setup.ps1
+++ b/setup.ps1
@@ -19,7 +19,7 @@ Options:
 This Windows-only PowerShell script will:
   - Verify required tools: node, npm, python3, pip3, uv (CORE DEPENDENCIES)
   - Install Ollama via winget
-  - Pull embedding model defined by EMBED_PATH (defaults to gemma3:4b)
+  - Pull embedding model defined by EMBED_PATH (defaults to nomic-embed-text:137m-v1.5-fp16)
   - Install root dependencies via npm
   - Bootstrap both root and backend .env files
   - Bootstrap backend venv and install Python deps via uv
@@ -197,7 +197,7 @@ if (-not (Get-Command "ollama" -ErrorAction SilentlyContinue)) {
 }
 
 # Determine embed model
-$EmbedModel = if ($env:EMBED_PATH) { $env:EMBED_PATH } else { "gemma3:4b" }
+$EmbedModel = if ($env:EMBED_PATH) { $env:EMBED_PATH } else { "nomic-embed-text:137m-v1.5-fp16" }
 
 # Pull Ollama model if EmbedModel looks like a model name
 if (Get-Command "ollama" -ErrorAction SilentlyContinue) {

--- a/setup.sh
+++ b/setup.sh
@@ -37,7 +37,7 @@ Options:
 
 This script will:
   • Verify required tools: node, npm, python3, pip3, uv
-  • Install Ollama & pull gemma3:4b model
+  • Install Ollama & pull nomic-embed-text:137m-v1.5-fp16 model
   • Install root dependencies via npm ci
   • Bootstrap both root and backend .env files
   • Bootstrap backend venv and install Python deps via uv


### PR DESCRIPTION
## Summary
- sync fallback embedding model for Windows and Linux setups
- update documentation about the default embedding model

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_688544c018008326911b2ba6ae0e5b5e