### PR TITLE
Add HF embedding provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The backend loads local models based on a few environment variables. Adjust thes
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `EMBED_PATH` | Name or path to a GGUF embedding model. | `nomic-embed-text:137m-v1.5-fp16` |
+| `EMBED_PATH` | Name or path to an embedding model (GGUF, `.pt` or HuggingFace ID). | `nomic-embed-text:137m-v1.5-fp16` |
 | `RERANK_PATH` | Path to a Qwen3 reranker `.safetensors` file. | `Qwen3-Reranker-8B-Q8_0.safetensors` |
 | `LLAMA_ARGS` | Extra flags passed to the Llama backend (dashes become underscores). | `""` |
 | `ENABLE_RERANK` | Enable the reranking stage with the model above. | `false` |
@@ -103,6 +103,12 @@ export EMBED_PATH=/path/to/Qwen3-Embed-Model.gguf
 export RERANK_PATH=/path/to/Qwen3-Reranker-8B-Q8_0.safetensors
 export ENABLE_RERANK=true
 export LLAMA_ARGS="--n-gpu-layers=1"
+```
+
+Example using a HuggingFace embedding model:
+
+```bash
+export EMBED_PATH=thenlper/gte-small
 ```
 
 Dashes in keys are converted to underscores, so the example above becomes `n_gpu_layers=1` when parsed.

--- a/SETUP.md
+++ b/SETUP.md
@@ -103,7 +103,7 @@ You can customize any variables in these files before or after bootstrapping.
 | `PYTHONDONTWRITEBYTECODE` | Disable Python bytecode files   | `1`                            |
 | `ASYNC_DATABASE_URL`      | Backend async db connection URI | `sqlite+aiosqlite:///./app.db` |
 | `NEXT_PUBLIC_API_URL`     | Frontend proxy to backend URI   | `http://localhost:8000`        |
-| `EMBED_PATH`              | Name or path to embedding model  | `nomic-embed-text:137m-v1.5-fp16` |
+| `EMBED_PATH`              | Name or path to an embedding model (GGUF, `.pt` or HuggingFace ID) | `nomic-embed-text:137m-v1.5-fp16` |
 | `RERANK_PATH`             | Path to Qwen3 reranker model     | `Qwen3-Reranker-8B-Q8_0.safetensors` |
 | `LLAMA_ARGS`              | Extra arguments for llama backend (dashes become underscores). | `""` |
 | `ENABLE_RERANK`           | Enable reranking stage           | `false` |
@@ -117,6 +117,12 @@ export EMBED_PATH=/path/to/Qwen3-Embed-Model.gguf
 export RERANK_PATH=/path/to/Qwen3-Reranker-8B-Q8_0.safetensors
 export ENABLE_RERANK=true
 export LLAMA_ARGS="--n-gpu-layers=1"
+```
+
+To load a HuggingFace model instead:
+
+```bash
+export EMBED_PATH=thenlper/gte-small
 ```
 
 Dashes in keys are converted to underscores, so the example above becomes `n_gpu_layers=1` when parsed.

--- a/apps/backend/app/agent/manager.py
+++ b/apps/backend/app/agent/manager.py
@@ -6,6 +6,7 @@ from .strategies.wrapper import JSONWrapper, MDWrapper
 from .providers.ollama import OllamaProvider, OllamaEmbeddingProvider
 from .providers.openai import OpenAIProvider, OpenAIEmbeddingProvider
 from .providers.gguf import GGUFEmbeddingProvider
+from .providers.hf import HFEmbeddingProvider
 
 
 class AgentManager:
@@ -57,6 +58,10 @@ class EmbeddingManager:
             if not os.path.isfile(model):
                 raise ProviderError(f"Embedding file '{model}' not found")
             return GGUFEmbeddingProvider(model)
+        if model.endswith(".pt") or "/" in model:
+            if model.endswith(".pt") and not os.path.isfile(model):
+                raise ProviderError(f"Embedding file '{model}' not found")
+            return HFEmbeddingProvider(model)
         installed_ollama_models = await OllamaProvider.get_installed_models()
         if model not in installed_ollama_models:
             raise ProviderError(

--- a/apps/backend/app/agent/providers/hf.py
+++ b/apps/backend/app/agent/providers/hf.py
@@ -1,0 +1,29 @@
+import logging
+from typing import List
+
+from fastapi.concurrency import run_in_threadpool
+from sentence_transformers import SentenceTransformer
+
+from .base import EmbeddingProvider
+from ..exceptions import ProviderError
+
+logger = logging.getLogger(__name__)
+
+
+class HFEmbeddingProvider(EmbeddingProvider):
+    """Embedding provider using HuggingFace sentence-transformers."""
+
+    def __init__(self, model_name: str) -> None:
+        try:
+            self._model = SentenceTransformer(model_name)
+        except Exception as e:  # pragma: no cover - runtime error if model fails
+            logger.error(f"hf load error: {e}")
+            raise ProviderError(f"HF - Error loading embedding model: {e}") from e
+
+    async def embed(self, text: str) -> List[float]:
+        try:
+            embedding = await run_in_threadpool(self._model.encode, text)
+            return embedding.tolist()
+        except Exception as e:  # pragma: no cover - runtime error if model fails
+            logger.error(f"hf embedding error: {e}")
+            raise ProviderError(f"HF - Error generating embedding: {e}") from e

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "typing_extensions==4.13.1",
     "urllib3==2.4.0",
     "uvicorn==0.34.0",
+    "sentence-transformers==2.7.0",
 ]
 
 [build-system]

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -55,3 +55,4 @@ typing_extensions==4.13.1
 urllib3==2.4.0
 uvicorn==0.34.0
 exllamav2==0.3.2
+sentence-transformers==2.7.0


### PR DESCRIPTION
## Summary
- add new `HFEmbeddingProvider` powered by sentence-transformers
- support HuggingFace models or `.pt` files in `EmbeddingManager`
- document HF embedding usage examples in README and SETUP docs
- include sentence-transformers dependency

## Testing
- `python -m compileall -q apps/backend/app`

------
https://chatgpt.com/codex/tasks/task_e_68854abe72ec8326ac02b92d8aadae3f