### PR TITLE
Add ResumeDoc SQLAlchemy model

### DIFF
--- a/apps/backend/db/__init__.py
+++ b/apps/backend/db/__init__.py
@@ -1,0 +1,5 @@
+# Database models package
+
+from .models import ResumeDoc
+
+__all__ = ["ResumeDoc"]

--- a/apps/backend/db/models.py
+++ b/apps/backend/db/models.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, Integer, String, DateTime, LargeBinary, UniqueConstraint
+from sqlalchemy.types import JSON
+import sqlalchemy as sa
+
+from apps.backend.app.models.base import Base
+
+
+class ResumeDoc(Base):
+    __tablename__ = "resumedoc"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    hash = Column(String(64), nullable=False)
+    model_hash = Column(String(64), nullable=False)
+    filename = Column(String, nullable=False)
+    display_name = Column(String, nullable=True)
+    upload_dt = Column(DateTime(timezone=True), server_default=sa.func.now())
+    parsed_json = Column(JSON, nullable=True)
+    vector = Column(LargeBinary, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("hash", "model_hash", name="uq_resume_hash_model"),
+    )
+


### PR DESCRIPTION
## Summary
- add `ResumeDoc` table definition
- expose `ResumeDoc` from the db package so Alembic can find it

## Testing
- `pytest -q`
- `python -m py_compile apps/backend/db/models.py apps/backend/db/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6886631845bc8326b43aa160159def4d