### PR TITLE
Add Alembic migration for ResumeDoc

### DIFF
--- a/backend/db/migrations/versions/6e8681181d11_add_resume_doc.py
+++ b/backend/db/migrations/versions/6e8681181d11_add_resume_doc.py
@@ -1,0 +1,33 @@
+"""add resume doc table
+
+Revision ID: 6e8681181d11
+Revises: 
+Create Date: 2025-07-27
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '6e8681181d11'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'resumedoc',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('hash', sa.String(length=64), nullable=False),
+        sa.Column('model_hash', sa.String(length=64), nullable=False),
+        sa.Column('filename', sa.String(), nullable=False),
+        sa.Column('display_name', sa.String(), nullable=True),
+        sa.Column('upload_dt', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('parsed_json', sa.JSON(), nullable=True),
+        sa.Column('vector', sa.LargeBinary(), nullable=True),
+        sa.UniqueConstraint('hash', 'model_hash', name='uq_resume_hash_model')
+    )
+
+def downgrade():
+    op.drop_table('resumedoc')
+


### PR DESCRIPTION
## Summary
- add backend db migrations directory
- create Alembic revision `add_resume_doc` to create the `resumedoc` table

## Testing
- `python -m compileall -q backend/db/migrations/versions/6e8681181d11_add_resume_doc.py`
- `python -m compileall -q apps/backend/app`


------
https://chatgpt.com/codex/tasks/task_e_6886652bc988832688f0ea93346d9c0c