### PR TITLE
Add SHA-256 utility functions with tests

### DIFF
--- a/apps/backend/app/services/utils.py
+++ b/apps/backend/app/services/utils.py
@@ -1,0 +1,27 @@
+import functools
+import hashlib
+from pathlib import Path
+from typing import Union
+
+CHUNK_SIZE = 128 * 1024  # 128 KiB
+
+
+def file_sha256(data_or_path: Union[bytes, str, Path]) -> str:
+    """Return SHA-256 hex digest for bytes or file."""
+    hasher = hashlib.sha256()
+    if isinstance(data_or_path, (str, Path)):
+        path = Path(data_or_path)
+        with path.open('rb') as f:
+            for chunk in iter(lambda: f.read(CHUNK_SIZE), b""):
+                hasher.update(chunk)
+    elif isinstance(data_or_path, (bytes, bytearray)):
+        hasher.update(data_or_path)
+    else:
+        raise TypeError("data_or_path must be bytes or path-like")
+    return hasher.hexdigest()
+
+
+@functools.lru_cache(maxsize=None)
+def model_sha256(model_path: Union[str, Path]) -> str:
+    """Return SHA-256 hex digest for a model file."""
+    return file_sha256(model_path)

--- a/tests/test_hash_utils.py
+++ b/tests/test_hash_utils.py
@@ -1,0 +1,28 @@
+import hashlib
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UTILS_PATH = ROOT / "apps" / "backend" / "app" / "services" / "utils.py"
+
+spec = importlib.util.spec_from_file_location("hash_utils", UTILS_PATH)
+hash_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hash_utils)
+file_sha256 = hash_utils.file_sha256
+model_sha256 = hash_utils.model_sha256
+
+
+def test_file_sha256_bytes():
+    data = b"hello"
+    expected = hashlib.sha256(data).hexdigest()
+    assert file_sha256(data) == expected
+
+
+def test_model_sha256_tmp_file(tmp_path):
+    file_path = tmp_path / "test.bin"
+    content = b"sample content"
+    file_path.write_bytes(content)
+
+    first = model_sha256(file_path)
+    second = model_sha256(str(file_path))
+    assert first == second == hashlib.sha256(content).hexdigest()


### PR DESCRIPTION
## Summary
- add `file_sha256` and `model_sha256` utility functions for hashing files
- memoise model hashing and expose a chunked reader
- add unit tests covering both utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688666a4a78c83269fbb65e0a489368b