### PR TITLE
Add structlog logging config

### DIFF
--- a/apps/backend/app/logging_config.py
+++ b/apps/backend/app/logging_config.py
@@ -1,0 +1,36 @@
+import os
+import logging
+from logging.handlers import RotatingFileHandler
+
+import structlog
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+ENV = os.getenv("ENV", "dev").lower()
+
+os.makedirs("logs", exist_ok=True)
+log_file = os.path.join("logs", "backend.log")
+
+handler = RotatingFileHandler(log_file, maxBytes=5 * 1024 * 1024, backupCount=3)
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(message)s",
+    handlers=[handler, logging.StreamHandler()],
+)
+
+renderer = (
+    structlog.processors.JSONRenderer()
+    if ENV == "prod"
+    else structlog.dev.ConsoleRenderer()
+)
+
+structlog.configure(
+    processors=[
+        structlog.processors.TimeStamper(fmt="iso"),
+        renderer,
+    ],
+    wrapper_class=structlog.make_filtering_bound_logger(
+        getattr(logging, LOG_LEVEL, logging.INFO)
+    ),
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    cache_logger_on_first_use=True,
+)

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,3 +1,4 @@
+from . import logging_config  # configure logging before the app is created
 import uvicorn
 from .base import create_app
 

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -56,3 +56,4 @@ urllib3==2.4.0
 uvicorn==0.34.0
 exllamav2==0.3.2
 sentence-transformers==2.7.0
+structlog>=24.1


### PR DESCRIPTION
## Summary
- add structlog dependency for backend
- configure structlog logging with rotating file handler
- import logging config before creating the FastAPI app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867010be9c8326bbeabb1eb09877d9