### PR TITLE
Add upload size limit test

### DIFF
--- a/apps/backend/app/api/router/v1/resume.py
+++ b/apps/backend/app/api/router/v1/resume.py
@@ -81,6 +81,11 @@ async def upload_resume(
         )
 
     file_bytes = await file.read()
+    if len(file_bytes) > 2_000_000:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="File too large",
+        )
     if not file_bytes:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tests/test_local_qwen_rewriter.py
+++ b/tests/test_local_qwen_rewriter.py
@@ -8,6 +8,7 @@ import types
 ROOT = Path(__file__).resolve().parents[1]
 SERVICE_PATH = ROOT / "apps" / "backend" / "app" / "services" / "local_qwen_rewriter.py"
 sys.path.insert(0, str(ROOT / "apps" / "backend"))
+import fastapi  # ensure real FastAPI is available
 sys.modules.setdefault("ollama", types.ModuleType("ollama"))
 fastapi_mod = types.ModuleType("fastapi")
 fastapi_conc = types.ModuleType("fastapi.concurrency")
@@ -22,6 +23,11 @@ openai_mod.OpenAI = object
 sys.modules.setdefault("openai", openai_mod)
 sys.modules.setdefault("sentence_transformers", types.ModuleType("sentence_transformers"))
 sys.modules["sentence_transformers"].SentenceTransformer = object
+llm_stub = types.ModuleType("app.llm")
+llm_stub.ensure_gguf = lambda *a, **k: None
+llm_stub.parse_llama_args = lambda *a, **k: {}
+llm_stub.get_embedding = lambda *a, **k: [0.0]
+sys.modules.setdefault("app.llm", llm_stub)
 
 spec = importlib.util.spec_from_file_location("local_qwen_rewriter", SERVICE_PATH)
 module = importlib.util.module_from_spec(spec)

--- a/tests/test_upload_size_limit.py
+++ b/tests/test_upload_size_limit.py
@@ -1,0 +1,12 @@
+import io
+from fastapi import UploadFile
+from starlette.datastructures import Headers
+from test_upload_cache import client
+
+
+def test_upload_size_limit(client):
+    data = b"x" * 3_000_000
+    file = UploadFile(io.BytesIO(data), filename="big.pdf", headers=Headers({"content-type": "application/pdf"}))
+    files = {"file": (file.filename, file.file, file.content_type)}
+    resp = client.post("/api/v1/resumes/upload", files=files)
+    assert resp.status_code == 413


### PR DESCRIPTION
## Summary
- enforce 2 MB upload limit on resume upload
- stub missing app.llm module in rewriter test
- add regression test for uploads larger than 2 MB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886902f300c8326b8c0b99c059236ba